### PR TITLE
Add support for program holes and tuning

### DIFF
--- a/src/compiler/anf.mc
+++ b/src/compiler/anf.mc
@@ -1,0 +1,11 @@
+include "mexpr/anf.mc"
+
+include "ast.mc"
+
+lang OCamlOpaqueANF = ANF + OpaqueOCamlAst
+  sem normalize (k : Expr -> Expr) =
+  | TmOpaqueOCaml t -> k (TmOpaqueOCaml t)
+end
+
+lang OCamlExtrasANF = OCamlOpaqueANF
+end

--- a/src/compiler/cfa.mc
+++ b/src/compiler/cfa.mc
@@ -2,7 +2,7 @@ include "mexpr/cfa.mc"
 
 include "ast.mc"
 
-lang OCamlStringCFA = CFA + ConstCFA + OCamlStringAst
+lang OCamlStringCFA = ConstCFA + OCamlStringAst
   sem generateConstraintsConst graph info ident =
   | COString _ -> graph
 end
@@ -13,7 +13,7 @@ lang OCamlOpaqueCFA = CFA + OpaqueOCamlAst
 
 end
 
-lang OCamlListCFA = PrettyPrint + OCamlListAst
+lang OCamlListCFA = ConstCFA + OCamlListAst
   sem generateConstraintsConst graph info ident =
   | CONil _ -> graph
   | COCons _ -> graph

--- a/src/compiler/cfa.mc
+++ b/src/compiler/cfa.mc
@@ -1,0 +1,23 @@
+include "mexpr/cfa.mc"
+
+include "ast.mc"
+
+lang OCamlStringCFA = CFA + ConstCFA + OCamlStringAst
+  sem generateConstraintsConst graph info ident =
+  | COString _ -> graph
+end
+
+lang OCamlOpaqueCFA = CFA + OpaqueOCamlAst
+  sem generateConstraints graph =
+  | TmLet { ident = ident, body = TmOpaqueOCaml _, info = info } -> graph
+
+end
+
+lang OCamlListCFA = PrettyPrint + OCamlListAst
+  sem generateConstraintsConst graph info ident =
+  | CONil _ -> graph
+  | COCons _ -> graph
+end
+
+lang OCamlExtrasCFA = OCamlStringCFA + OCamlOpaqueCFA + OCamlListCFA
+end

--- a/src/compiler/const-arity.mc
+++ b/src/compiler/const-arity.mc
@@ -7,7 +7,7 @@ lang OCamlStringConstArity = ConstArity + OCamlStringAst
   | COString _ -> 0
 end
 
-lang OCamlListConstArity = PrettyPrint + OCamlListAst
+lang OCamlListConstArity = ConstArity + OCamlListAst
   sem constArity =
   | CONil _ -> 0
   | COCons _ -> 2

--- a/src/compiler/const-arity.mc
+++ b/src/compiler/const-arity.mc
@@ -1,0 +1,17 @@
+include "mexpr/const-arity.mc"
+
+include "ast.mc"
+
+lang OCamlStringConstArity = ConstArity + OCamlStringAst
+  sem constArity =
+  | COString _ -> 0
+end
+
+lang OCamlListConstArity = PrettyPrint + OCamlListAst
+  sem constArity =
+  | CONil _ -> 0
+  | COCons _ -> 2
+end
+
+lang OCamlExtrasConstArity = OCamlStringConstArity + OCamlListConstArity
+end

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -278,8 +278,11 @@ let ast =
        writeFile path (pprintAst ast)
      else ());
     ast
+  else ast
+in
 
-  else if options.useTuning then
+let ast =
+  if options.useTuning then
     match options.inputTunedValues with Some path then
       use MExprTuning in
       let table = tuneFileReadTable path in

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -6,6 +6,12 @@ include "mexpr/shallow-patterns.mc"
 include "mexpr/phase-stats.mc"
 include "mexpr/reptypes.mc"
 include "ocaml/mcore.mc"
+include "tuning/ast.mc"
+include "tuning/context-expansion.mc"
+include "tuning/dependency-analysis.mc"
+include "tuning/instrumentation.mc"
+include "tuning/tune.mc"
+include "tuning/tune-file.mc"
 
 -- local
 include "syntax.mc"
@@ -16,6 +22,9 @@ include "type-check.mc"
 include "shallow-patterns.mc"
 include "generate.mc"
 include "cmp.mc"
+include "anf.mc"
+include "cfa.mc"
+include "const-arity.mc"
 
 lang MCoreCompile
   = OCamlAst
@@ -45,6 +54,7 @@ lang MCoreCompile
   + RepTypesSym
   + RepTypesTypeCheck
   + ShallowOCamlExtras
+  + HoleAst
 end
 
 lang RepAnalysis
@@ -80,6 +90,27 @@ lang MExprRepTypesComposedSolver
   | ty -> errorSingle [infoTy ty] "Missing getTypeStringCode"
 end
 
+lang MExprTune
+  = MExprHoles
+  + MExprHoleCFA
+  + NestedMeasuringPoints
+  + DependencyAnalysis
+  + Instrumentation
+  + TuneBase
+  + MExprTypeCheck
+  + OCamlExtrasTypeCheck
+  + OCamlExtrasPprint
+  + OCamlExtrasANF
+  + OCamlExtrasCFA
+  + OCamlExtrasConstArity
+end
+
+lang MExprTuneANFAll
+  = HoleAst
+  + MExprANFAll
+  + OCamlExtrasANF
+end
+
 mexpr
 
 use MCoreCompile in
@@ -88,6 +119,7 @@ let options =
   { olibs = []
   , clibs = []
   , useRepr = true
+  , useTuning = true
   , debugMExpr = None ()
   , debugRepr = None ()
   , debugAnalysis = None ()
@@ -97,6 +129,9 @@ let options =
   , debugSolveTiming = false
   , destinationFile = None ()
   , jsonPath = None ()
+  , inputTunedValues = None ()
+  , outputTunedValues = None ()
+  , dependencyAnalysis = true
   } in
 let argConfig =
   [ ( [("--olib", " ", "<package>")]
@@ -114,7 +149,7 @@ let argConfig =
 
   -- Reptypes related options
   , ( [("--no-repr", "", "")]
-    , "Turn of the repr-passes (i.e., programs that contain repr will fail to compile, possibly loudly)."
+    , "Turn off the repr-passes (i.e., programs that contain repr will fail to compile, possibly loudly)."
     , lam p. { p.options with useRepr = false }
     )
   , ( [("--debug-mexpr", " ", "<path>")]
@@ -156,7 +191,45 @@ let argConfig =
     , "Output the connections between representations and operations in JSON format."
     , lam p. { p.options with jsonPath = Some (argToString p) }
     )
+
+  -- Tuning related options
+  , ( [("--no-tuning", "", "")]
+    , "Turn off the tuning-passes (i.e., programs that contain holes will fail to compile, possibly loudly)."
+    , lam p. { p.options with useTuning = false }
+    )
+  , ( [("--with-tuned-values", " ", "<path>")]
+    , "Compile with tuned values from this file (no tuning)."
+    , lam p. { p.options with inputTunedValues = Some (argToString p) }
+    )
+  , ( [("--tune", " ", "<path>")]
+    , "Perform tuning and write tuned values to this file."
+    , lam p. { p.options with outputTunedValues = Some (argToString p) }
+    )
+  , ( [("--no-dependency-analysis", "", "")]
+    , "Do not perform dependency analysis before tuning."
+    , lam p. { p.options with dependencyAnalysis = false }
+    )
   ] in
+
+let compile: Expr -> String -> () = lam ast. lam destinationFile.
+  compileMCore ast
+    { debugTypeAnnot = lam. ()
+    , debugGenerate = lam. ()
+    , exitBefore = lam. ()
+    , postprocessOcamlTops = lam x. x
+    , compileOcaml = lam libs. lam clibs. lam srcStr.
+      let config =
+        { optimize = true
+        , libraries = concat libs options.olibs
+        , cLibraries = concat clibs options.clibs
+        } in
+      let res = ocamlCompileWithConfig config srcStr in
+      sysMoveFile res.binaryPath destinationFile;
+      sysChmodWriteAccessFile destinationFile;
+      res.cleanup ();
+      ()
+    }
+in
 
 match
   let res = argParse options argConfig in
@@ -204,6 +277,52 @@ let ast =
        writeFile path (pprintAst ast)
      else ());
     ast
+
+  else if options.useTuning then
+    match options.inputTunedValues with Some path then
+      use MExprTune in
+      let table = tuneFileReadTable path in
+      let ast = normalizeTerm ast in
+      match colorCallGraph [] ast with (env, ast) in
+      insert env table ast
+
+    else match options.outputTunedValues with Some path then
+      use MExprTune in
+      let ast = normalizeTerm ast in
+      match colorCallGraph [] ast with (env, cAst) in
+
+      match
+        if options.dependencyAnalysis then
+          let ast = use MExprTuneANFAll in normalizeTerm cAst in
+          let cfaRes = holeCfa (graphDataInit env) ast in
+          let cfaRes = analyzeNested env cfaRes ast in
+          (analyzeDependency env cfaRes ast, ast)
+        else assumeFullDependency env cAst
+      with (dep, ast) in
+
+      match instrument env dep ast with (instRes, ast) in
+      match contextExpand env ast with (r, ast) in
+
+      let ast = stripTuneAnnotations ast in
+      let ast = typeCheckLeaveMeta ast in
+      let ast = removeMetaVarExpr ast in
+      let ast = lowerAll ast in
+
+      let tuneBinary = sysJoinPath r.tempDir "tune" in
+      compile ast tuneBinary;
+
+      let result = tuneEntry tuneBinary tuneOptionsDefault env dep instRes r ast in
+      tuneFileDumpTable path env result true;
+
+      r.cleanup();
+      instRes.cleanup();
+
+      insert env result cAst
+
+    else
+      let ast = stripTuneAnnotations ast in
+      default ast
+
   else ast
 in
 
@@ -212,22 +331,4 @@ let ast = lowerAll ast in
 
 match options.destinationFile with Some destinationFile in
 
-compileMCore ast
-  { debugTypeAnnot = lam. ()
-  , debugGenerate = lam. ()
-  , exitBefore = lam. ()
-  , postprocessOcamlTops = lam x. x
-  , compileOcaml = lam libs. lam clibs. lam srcStr.
-    let config =
-      { optimize = true
-      , libraries = concat libs options.olibs
-      , cLibraries = concat clibs options.clibs
-      } in
-    let res = ocamlCompileWithConfig config srcStr in
-    sysMoveFile res.binaryPath destinationFile;
-    sysChmodWriteAccessFile destinationFile;
-    res.cleanup ();
-    ()
-  };
-
-()
+compile ast destinationFile

--- a/src/compiler/syntax.syn
+++ b/src/compiler/syntax.syn
@@ -148,6 +148,11 @@ prod Con : OExpr = n:UName
 prod List : OExpr = "[" unbrokenElems:OExpr? "]"
 prod Array : OExpr = "[|" unbrokenElems:OExpr? "|]"
 prod Unit : OExpr = "()"
+prod Hole : OExpr =
+  "hole" "{"
+    (fields:{name:LName "=" val:OExpr}
+     fields:{"|" name:LName "=" val:OExpr}*)?
+  "}"
 -- NOTE(vipa, 2023-11-03): This breaks compatibility with OCaml, it
 -- has `@` as an infix operator
 prod ScaleBase : OExpr = "@"


### PR DESCRIPTION
Adds program holes (syntax + conversion to MExpr terms) as well as the capability of performing tuning in the compiler.

This PR must be merged together with https://github.com/miking-lang/miking/pull/814.