### PR TITLE
Add comparison operators

### DIFF
--- a/src/compiler/ast.mc
+++ b/src/compiler/ast.mc
@@ -132,20 +132,38 @@ lang OCamlListAst = Ast + ConstAst + TyConst
   | PatONil x -> PatONil {x with ty = ty}
 end
 
-lang OCamlCmpAst = OverloadedOpAst + CmpIntAst + CmpFloatAst + IntTypeAst
-                 + FloatTypeAst
+lang OCamlCmpAst = OverloadedOpAst + CmpIntTypeAst + CmpFloatTypeAst
+                 + IntTypeAst + FloatTypeAst
   -- Overloaded operator
   syn Op =
+  | OpEq
+  | OpNeq
   | OpLt
+  | OpGt
+  | OpLeq
+  | OpGeq
 
   sem opMkTypes info env =
-  | OpLt _ ->
+  | OpEq _ | OpNeq _ | OpLt _ | OpGt _ | OpLeq _ | OpGeq _ ->
     let ty = newmonovar env.currentLvl info in
     {params = [ty, ty], return = tyWithInfo info tybool_}
 
   sem resolveOp info =
-  | x & {op = OpLt _, params = [TyInt _] ++ _} ->
-    withInfo info (const_ x.return (CLti ()))
-  | x & {op = OpLt _, params = [TyFloat _] ++ _} ->
-    withInfo info (const_ x.return (CLtf ()))
+  | x & {op = OpEq _, params = [TyInt _] ++ _}   -> mkConst info (CEqi ())
+  | x & {op = OpEq _, params = [TyFloat _] ++ _} -> mkConst info (CEqf ())
+
+  | x & {op = OpNeq _, params = [TyInt _] ++ _}   -> mkConst info (CNeqi ())
+  | x & {op = OpNeq _, params = [TyFloat _] ++ _} -> mkConst info (CNeqf ())
+
+  | x & {op = OpLt _, params = [TyInt _] ++ _}   -> mkConst info (CLti ())
+  | x & {op = OpLt _, params = [TyFloat _] ++ _} -> mkConst info (CLtf ())
+
+  | x & {op = OpGt _, params = [TyInt _] ++ _}   -> mkConst info (CGti ())
+  | x & {op = OpGt _, params = [TyFloat _] ++ _} -> mkConst info (CGtf ())
+
+  | x & {op = OpLeq _, params = [TyInt _] ++ _}   -> mkConst info (CLeqi ())
+  | x & {op = OpLeq _, params = [TyFloat _] ++ _} -> mkConst info (CLeqf ())
+
+  | x & {op = OpGeq _, params = [TyInt _] ++ _}   -> mkConst info (CGeqi ())
+  | x & {op = OpGeq _, params = [TyFloat _] ++ _} -> mkConst info (CGeqf ())
 end

--- a/src/compiler/ast.mc
+++ b/src/compiler/ast.mc
@@ -1,4 +1,5 @@
 include "mexpr/ast.mc"
+include "mexpr/op-overload.mc"
 
 lang OpaqueOCamlAst = Ast
   -- Expr
@@ -129,4 +130,22 @@ lang OCamlListAst = Ast + ConstAst + TyConst
   sem withTypePat ty =
   | PatOCons x -> PatOCons {x with ty = ty}
   | PatONil x -> PatONil {x with ty = ty}
+end
+
+lang OCamlCmpAst = OverloadedOpAst + CmpIntAst + CmpFloatAst + IntTypeAst
+                 + FloatTypeAst
+  -- Overloaded operator
+  syn Op =
+  | OpLt
+
+  sem opMkTypes info env =
+  | OpLt _ ->
+    let ty = newmonovar env.currentLvl info in
+    {params = [ty, ty], return = tyWithInfo info tybool_}
+
+  sem resolveOp info =
+  | x & {op = OpLt _, params = [TyInt _] ++ _} ->
+    withInfo info (const_ x.return (CLti ()))
+  | x & {op = OpLt _, params = [TyFloat _] ++ _} ->
+    withInfo info (const_ x.return (CLtf ()))
 end

--- a/src/compiler/convert.mc
+++ b/src/compiler/convert.mc
@@ -469,7 +469,6 @@ lang ConvertGeqOExpr = ConvertOCamlToMExpr + GeqOExprAst + OCamlCmpAst
   )
 end
 
-
 lang ConvertTupOExpr = ConvertOCamlToMExpr + TupOExprAst
   sem convExpr =
   | tm & TupOExpr x -> withInfo x.info (utuple_ (tupList tm))

--- a/src/compiler/convert.mc
+++ b/src/compiler/convert.mc
@@ -415,6 +415,24 @@ lang ConvertDivfOExpr = ConvertOCamlToMExpr + DivfOExprAst + ArithFloatAst
     (convExpr x.right))
 end
 
+lang ConvertEqOExpr = ConvertOCamlToMExpr + EqOExprAst + OCamlCmpAst
+  sem convExpr =
+  | EqOExpr x -> withInfo x.info (appf2_
+    (mkOp x.info (OpEq ()))
+    (convExpr x.left)
+    (convExpr x.right)
+  )
+end
+
+lang ConvertNeqOExpr = ConvertOCamlToMExpr + NeqOExprAst + OCamlCmpAst
+  sem convExpr =
+  | NeqOExpr x -> withInfo x.info (appf2_
+    (mkOp x.info (OpNeq ()))
+    (convExpr x.left)
+    (convExpr x.right)
+  )
+end
+
 lang ConvertLtOExpr = ConvertOCamlToMExpr + LtOExprAst + OCamlCmpAst
   sem convExpr =
   | LtOExpr x -> withInfo x.info (appf2_
@@ -423,6 +441,34 @@ lang ConvertLtOExpr = ConvertOCamlToMExpr + LtOExprAst + OCamlCmpAst
     (convExpr x.right)
   )
 end
+
+lang ConvertGtOExpr = ConvertOCamlToMExpr + GtOExprAst + OCamlCmpAst
+  sem convExpr =
+  | GtOExpr x -> withInfo x.info (appf2_
+    (mkOp x.info (OpGt ()))
+    (convExpr x.left)
+    (convExpr x.right)
+  )
+end
+
+lang ConvertLeqOExpr = ConvertOCamlToMExpr + LeqOExprAst + OCamlCmpAst
+  sem convExpr =
+  | LeqOExpr x -> withInfo x.info (appf2_
+    (mkOp x.info (OpLeq ()))
+    (convExpr x.left)
+    (convExpr x.right)
+  )
+end
+
+lang ConvertGeqOExpr = ConvertOCamlToMExpr + GeqOExprAst + OCamlCmpAst
+  sem convExpr =
+  | GeqOExpr x -> withInfo x.info (appf2_
+    (mkOp x.info (OpGeq ()))
+    (convExpr x.left)
+    (convExpr x.right)
+  )
+end
+
 
 lang ConvertTupOExpr = ConvertOCamlToMExpr + TupOExprAst
   sem convExpr =
@@ -747,7 +793,12 @@ lang ComposedConvertOCamlToMExpr
   + ConvertConsOExpr
   + ConvertConsOPat
   + ConvertDivfOExpr
+  + ConvertEqOExpr
+  + ConvertNeqOExpr
   + ConvertLtOExpr
+  + ConvertGtOExpr
+  + ConvertLeqOExpr
+  + ConvertGeqOExpr
   + ConvertDiviOExpr
   + ConvertFalseOExpr
   + ConvertFalseOPat

--- a/src/compiler/convert.mc
+++ b/src/compiler/convert.mc
@@ -415,6 +415,15 @@ lang ConvertDivfOExpr = ConvertOCamlToMExpr + DivfOExprAst + ArithFloatAst
     (convExpr x.right))
 end
 
+lang ConvertLtOExpr = ConvertOCamlToMExpr + LtOExprAst + OCamlCmpAst
+  sem convExpr =
+  | LtOExpr x -> withInfo x.info (appf2_
+    (mkOp x.info (OpLt ()))
+    (convExpr x.left)
+    (convExpr x.right)
+  )
+end
+
 lang ConvertTupOExpr = ConvertOCamlToMExpr + TupOExprAst
   sem convExpr =
   | tm & TupOExpr x -> withInfo x.info (utuple_ (tupList tm))
@@ -738,6 +747,7 @@ lang ComposedConvertOCamlToMExpr
   + ConvertConsOExpr
   + ConvertConsOPat
   + ConvertDivfOExpr
+  + ConvertLtOExpr
   + ConvertDiviOExpr
   + ConvertFalseOExpr
   + ConvertFalseOPat

--- a/src/compiler/pprint.mc
+++ b/src/compiler/pprint.mc
@@ -58,5 +58,13 @@ lang OCamlListPprint = PrettyPrint + OCamlListAst + ConstPrettyPrint
   | PatONil x -> (env, "[]")
 end
 
-lang OCamlExtrasPprint = OCamlStringPprint + OCamlOpaquePprint + OCamlListPprint
+lang OCamlCmpPprint = PrettyPrint + OCamlCmpAst + OverloadedOpPrettyPrint
+  sem getOpStringCode indent env =
+  | OpLt _ -> (env, "<")
+
+  sem opIsAtomic =
+  | OpLt _ -> true
+end
+
+lang OCamlExtrasPprint = OCamlStringPprint + OCamlOpaquePprint + OCamlListPprint + OCamlCmpPprint
 end

--- a/src/compiler/pprint.mc
+++ b/src/compiler/pprint.mc
@@ -60,10 +60,15 @@ end
 
 lang OCamlCmpPprint = PrettyPrint + OCamlCmpAst + OverloadedOpPrettyPrint
   sem getOpStringCode indent env =
+  | OpEq _ -> (env, "=")
+  | OpNeq _ -> (env, "!=")
   | OpLt _ -> (env, "<")
+  | OpGt _ -> (env, ">")
+  | OpLeq _ -> (env, "<=")
+  | OpGeq _ -> (env, ">=")
 
   sem opIsAtomic =
-  | OpLt _ -> true
+  | OpEq _ | OpNeq _ | OpLt _ | OpGt _ | OpLeq _ | OpGeq _ -> true
 end
 
 lang OCamlExtrasPprint = OCamlStringPprint + OCamlOpaquePprint + OCamlListPprint + OCamlCmpPprint

--- a/src/compiler/syntax.syn
+++ b/src/compiler/syntax.syn
@@ -204,6 +204,7 @@ precedence {
   App;
   Muli Mulf Divi Divf;
   Addi Addf Subi Subf;
+  Eq Neq Lt Gt Leq Geq;
   Cons;
   ~Or And;
   Tup;

--- a/src/compiler/syntax.syn
+++ b/src/compiler/syntax.syn
@@ -176,6 +176,7 @@ infix left Muli : OExpr = op:"*"
 infix left Mulf : OExpr = op:"*."
 infix left Divi : OExpr = op:"/"
 infix left Divf : OExpr = op:"/."
+infix left Lt : OExpr = op:"<"
 
 infix left Tup : OExpr = ","
 infix left App : OExpr = empty

--- a/src/compiler/syntax.syn
+++ b/src/compiler/syntax.syn
@@ -176,7 +176,13 @@ infix left Muli : OExpr = op:"*"
 infix left Mulf : OExpr = op:"*."
 infix left Divi : OExpr = op:"/"
 infix left Divf : OExpr = op:"/."
+
+infix left Eq : OExpr = op:"="
+infix left Neq : OExpr = op:"!="
 infix left Lt : OExpr = op:"<"
+infix left Gt : OExpr = op:">"
+infix left Leq : OExpr = op:"<="
+infix left Geq : OExpr = op:">="
 
 infix left Tup : OExpr = ","
 infix left App : OExpr = empty


### PR DESCRIPTION
Adds comparison (`=`, `!=`, `<`, `>`, `<=`, `>=`) as overloaded operators. Their types are resolved either to `Int -> Int -> Bool` or `Float -> Float -> Bool` at compile time.

Additionally, this PR adds two flags `--debug-type-check` and `--debug-desugar` that pretty print the AST directly after type checking and desugaring, respectively.

This PR uses https://github.com/miking-lang/miking/pull/817.