### PR TITLE
Add support for MExpr `utest`s

### DIFF
--- a/src/compiler/convert.mc
+++ b/src/compiler/convert.mc
@@ -181,6 +181,19 @@ lang ConvertReprOTop = ConvertOCamlToMExpr + ReprOTopAst + ReprDeclAst + VarType
     }
 end
 
+lang ConvertUtestOTop = ConvertOCamlToMExpr + UTestOTopAst + UtestAst
+  sem convTop cont =
+  | UTestOTop x -> TmUtest
+    { test = convExpr x.test
+    , expected = convExpr x.expected
+    , tusing = optionMap convExpr x.tusing
+    , tonfail = optionMap convExpr x.onfail
+    , ty = tyunknown_
+    , info = x.info
+    , next = cont
+    }
+end
+
 -- Type bindings --
 
 lang ConvertSimpleOTyBinding = ConvertOCamlToMExpr + SimpleOTyBindingAst
@@ -837,6 +850,7 @@ lang ComposedConvertOCamlToMExpr
   + ConvertTypeOTop
   + ConvertUnitOExpr
   + ConvertUnitOPat
+  + ConvertUtestOTop
   + ConvertVarOExpr
   + ConvertVarOExpr
   + ConvertVarOType

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -6,6 +6,7 @@ include "mexpr/op-overload.mc"
 include "mexpr/shallow-patterns.mc"
 include "mexpr/phase-stats.mc"
 include "mexpr/reptypes.mc"
+include "mexpr/utest-generate.mc"
 include "ocaml/mcore.mc"
 include "tuning/ast.mc"
 include "tuning/context-expansion.mc"
@@ -42,6 +43,7 @@ lang MCoreCompile
   + MExprPrettyPrint
   + MExprSym
   + MExprTypeCheck
+  + MExprUtestGenerate
   + OCamlExtrasCmp
   + OCamlExtrasGenerate
   + OCamlExtrasPprint
@@ -134,6 +136,7 @@ let options =
   , debugSolveProcess = false
   , debugSolveTiming = false
   , destinationFile = None ()
+  , generateTests = false
   , jsonPath = None ()
   , inputTunedValues = None ()
   , outputTunedValues = None ()
@@ -151,6 +154,10 @@ let argConfig =
   , ( [("--output", " ", "<path>")]
     , "Place the final executable here."
     , lam p. { p.options with destinationFile = Some (argToString p) }
+    )
+  , ( [("--test", "", "")]
+    , "Generate utest code."
+    , lam p. { p.options with generateTests = true }
     )
   , ( [("--debug-mexpr", " ", "<path>")]
     , "Output an interactive (html) pprinted version of the AST just after conversion to MExpr."
@@ -278,6 +285,8 @@ let ast = desugarExpr ast in
 (match options.debugDesugar with Some path then
    writeFile path (pprintAst ast)
  else ());
+
+let ast = generateUtest options.generateTests ast in
 
 let ast =
   if options.useRepr then

--- a/src/compiler/syntax.syn
+++ b/src/compiler/syntax.syn
@@ -114,6 +114,10 @@ prod LetImplOTop : OTop =
 prod ReprOTop : OTop =
   "letrepr" n:LName "{" lhs:OType "=" rhs:OType "}"
 
+prod UTestOTop : OTop =
+  "utest" test:OExpr "with" expected:OExpr
+  ("using" tusing:OExpr)? ("else" onfail:OExpr)? ";;"
+
 -- Type bindings
 prod SimpleOTyBinding : OTyBinding =
  ( empty


### PR DESCRIPTION
This PR extends the language with a `utest` construct that compiles directly to an MExpr `utest` (when the flag `--test` is enabled). 

The reason I want to add `utest`s is that they are used as a way to check the correctness of each version of the program that arises when running tuning.

This PR is based on https://github.com/miking-lang/mi-ocaml/pull/3, the diff for just the `utest` part is found [here](https://github.com/miking-lang/mi-ocaml/pull/4/commits/ec6cbc028acabbc8101da744ad6b1eb6ec6acceb) . 