### PR TITLE
Update after miking changes + reptypes

### DIFF
--- a/src/compiler/ast.mc
+++ b/src/compiler/ast.mc
@@ -167,3 +167,6 @@ lang OCamlCmpAst = OverloadedOpAst + CmpIntTypeAst + CmpFloatTypeAst
   | x & {op = OpGeq _, params = [TyInt _] ++ _}   -> mkConst info (CGeqi ())
   | x & {op = OpGeq _, params = [TyFloat _] ++ _} -> mkConst info (CGeqf ())
 end
+
+lang OCamlExtrasAst = OCamlStringAst + OCamlListAst + OpaqueOCamlAst + OCamlCmpAst
+end

--- a/src/compiler/ast.mc
+++ b/src/compiler/ast.mc
@@ -50,7 +50,7 @@ lang OCamlStringAst = Ast + ConstAst + TyConst
   syn Const =
   | COString {val : String}
 
-  sem tyConst =
+  sem tyConstBase d =
   | COString _ -> TyOString {info = NoInfo ()}
 
   -- Type
@@ -83,7 +83,7 @@ lang OCamlListAst = Ast + ConstAst + TyConst
   | CONil ()
   | COCons ()
 
-  sem tyConst =
+  sem tyConstBase d =
   | CONil _ -> tyall_ "x"
     (TyOList {info = NoInfo (), elem = tyvar_ "x"})
   | COCons _ -> tyall_ "x" (tyarrows_

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -223,6 +223,7 @@ let options =
   , reprSolver = TreeSolverPartIndep ()
   , useRepr = true
   , useTuning = true
+  , solverCache = None ()
   , reprSolveAll = false
   , debugMExpr = None ()
   , debugTypeCheck = None ()
@@ -279,6 +280,10 @@ let argConfig =
   , ( [("--no-repr", "", "")]
     , "Turn off the repr-passes (i.e., programs that contain repr will fail to compile, possibly loudly)."
     , lam p. { p.options with useRepr = false }
+    )
+  , ( [("--solver-cache", " ", "<file>")]
+    , "Load/store solutions here, reusing them if possible"
+    , lam p. { p.options with solverCache = Some (argToString p) }
     )
   , ( [("--repr-solver", " ", "<solver>")]
     , "Pick the solver to use for picking letimpls"
@@ -459,6 +464,7 @@ recursive
         , debugSolveTiming = options.debugSolveTiming
         , debugImpls = options.debugImpls
         , solveAll = options.reprSolveAll
+        , solutionCacheFile = options.solverCache
         } in
       let asts = switch options.reprSolver
         case SATishSolver _ then use ComposedSATIshSolver in reprSolve reprOptions ast

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -165,9 +165,14 @@ lang ComposedTreeSolverMixed
   + TreeSolverMixed
 end
 
-lang ComposedTreeSolverStateless
+lang ComposedTreeSolverEnum
   = MExprRepTypesSolverBase
-  + TreeSolverStateless
+  + TreeSolverEnum
+end
+
+lang ComposedTreeSolverFast
+  = MExprRepTypesSolverBase
+  + TreeSolverFast
 end
 
 lang ComposedTreeSolverFilterByBest
@@ -209,10 +214,11 @@ con TreeSolverGuided : () -> SolverOption in
 con TreeSolverHomogeneous : () -> SolverOption in
 con TreeSolverMixed : () -> SolverOption in
 con TreeSolverZ3 : () -> SolverOption in
-con TreeSolverStateless : () -> SolverOption in
 con TreeSolverFilterByBest : () -> SolverOption in
 con TreeSolverExplore : () -> SolverOption in
 con TreeSolverPartIndep : () -> SolverOption in
+con TreeSolverEnum : () -> SolverOption in
+con TreeSolverFast : () -> SolverOption in
 
 let options =
   { olibs = []
@@ -303,10 +309,11 @@ let argConfig =
         , ("tree-homogeneous", TreeSolverHomogeneous ())
         , ("tree-z3", TreeSolverZ3 ())
         , ("tree-mixed", TreeSolverMixed ())
-        , ("tree-stateless", TreeSolverStateless ())
         , ("tree-filter-best", TreeSolverFilterByBest ())
         , ("tree-explore", TreeSolverExplore ())
         , ("tree-indep", TreeSolverPartIndep ())
+        , ("tree-enum", TreeSolverEnum ())
+        , ("tree-fast", TreeSolverFast ())
         , ("mixed-sat-lazy-greed", SolTreeLazySolver ())
         ] in
       let reprSolver = argToString p in
@@ -482,9 +489,10 @@ recursive
         case TreeSolverHomogeneous _ then use ComposedTreeSolverHomogeneous in reprSolve reprOptions ast
         case TreeSolverZ3 _ then use ComposedTreeSolverZ3 in reprSolve reprOptions ast
         case TreeSolverMixed _ then use ComposedTreeSolverMixed in reprSolve reprOptions ast
-        case TreeSolverStateless _ then use ComposedTreeSolverStateless in reprSolve reprOptions ast
         case TreeSolverFilterByBest _ then use ComposedTreeSolverFilterByBest in reprSolve reprOptions ast
         case TreeSolverExplore _ then use ComposedTreeSolverExplore in reprSolve reprOptions ast
+        case TreeSolverEnum _ then use ComposedTreeSolverEnum in reprSolve reprOptions ast
+        case TreeSolverFast _ then use ComposedTreeSolverFast in reprSolve reprOptions ast
         case TreeSolverPartIndep _ then use ComposedTreeSolverPartIndep in reprSolve reprOptions ast
         end in
       match asts with [ast] then

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -165,6 +165,21 @@ lang ComposedTreeSolverMixed
   + TreeSolverMixed
 end
 
+lang ComposedTreeSolverStateless
+  = MExprRepTypesSolverBase
+  + TreeSolverStateless
+end
+
+lang ComposedTreeSolverFilterByBest
+  = MExprRepTypesSolverBase
+  + TreeSolverFilterByBest
+end
+
+lang ComposedTreeSolverPartIndep
+  = MExprRepTypesSolverBase
+  + TreeSolverPartIndep
+end
+
 lang ComposedTreeSolverZ3
   = MExprRepTypesSolverBase
   + TreeSolverZ3
@@ -194,7 +209,10 @@ con TreeSolverGuided : () -> SolverOption in
 con TreeSolverHomogeneous : () -> SolverOption in
 con TreeSolverMixed : () -> SolverOption in
 con TreeSolverZ3 : () -> SolverOption in
+con TreeSolverStateless : () -> SolverOption in
+con TreeSolverFilterByBest : () -> SolverOption in
 con TreeSolverExplore : () -> SolverOption in
+con TreeSolverPartIndep : () -> SolverOption in
 
 let options =
   { olibs = []
@@ -202,7 +220,7 @@ let options =
   , doCompile = true
 
   -- , reprSolver = LazyTopDownSolver ()
-  , reprSolver = TreeSolverMixed ()
+  , reprSolver = TreeSolverPartIndep ()
   , useRepr = true
   , useTuning = true
   , reprSolveAll = false
@@ -215,6 +233,7 @@ let options =
   , debugFinalSolution = false
   , debugSolveProcess = false
   , debugSolveTiming = false
+  , debugImpls = false
   , destinationFile = None ()
   , generateTests = false
   , jsonPath = None ()
@@ -274,7 +293,10 @@ let argConfig =
         , ("tree-homogeneous", TreeSolverHomogeneous ())
         , ("tree-z3", TreeSolverZ3 ())
         , ("tree-mixed", TreeSolverMixed ())
+        , ("tree-stateless", TreeSolverStateless ())
+        , ("tree-filter-best", TreeSolverFilterByBest ())
         , ("tree-explore", TreeSolverExplore ())
+        , ("tree-indep", TreeSolverPartIndep ())
         , ("mixed-sat-lazy-greed", SolTreeLazySolver ())
         ] in
       let reprSolver = argToString p in
@@ -309,6 +331,10 @@ let argConfig =
   , ( [("--debug-solver-state", "", "")]
     , "Print debug information about the state of the solver after each op-use."
     , lam p. { p.options with debugSolverState = true }
+    )
+  , ( [("--debug-impls", "", "")]
+    , "Print debug information about each impl as it's parsed."
+    , lam p. { p.options with debugImpls = true }
     )
   , ( [("--debug-solve-timing", "", "")]
     , "Print debug information about the state of the solver after each op-use."
@@ -431,6 +457,7 @@ recursive
           else SDTNone ()
         , debugSolveProcess = options.debugSolveProcess
         , debugSolveTiming = options.debugSolveTiming
+        , debugImpls = options.debugImpls
         , solveAll = options.reprSolveAll
         } in
       let asts = switch options.reprSolver
@@ -444,7 +471,10 @@ recursive
         case TreeSolverHomogeneous _ then use ComposedTreeSolverHomogeneous in reprSolve reprOptions ast
         case TreeSolverZ3 _ then use ComposedTreeSolverZ3 in reprSolve reprOptions ast
         case TreeSolverMixed _ then use ComposedTreeSolverMixed in reprSolve reprOptions ast
+        case TreeSolverStateless _ then use ComposedTreeSolverStateless in reprSolve reprOptions ast
+        case TreeSolverFilterByBest _ then use ComposedTreeSolverFilterByBest in reprSolve reprOptions ast
         case TreeSolverExplore _ then use ComposedTreeSolverExplore in reprSolve reprOptions ast
+        case TreeSolverPartIndep _ then use ComposedTreeSolverPartIndep in reprSolve reprOptions ast
         end in
       match asts with [ast] then
         (match options.debugRepr with Some path then

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -139,6 +139,11 @@ lang ComposedMemoedTopDownSolver
   + MemoedTopDownSolver
 end
 
+lang ComposedPaperSolver
+  = MExprRepTypesSolverBase
+  + PaperSolver
+end
+
 mexpr
 
 use MCoreCompile in
@@ -148,6 +153,7 @@ con SATishSolver : () -> SolverOption in
 con LazyTopDownSolver : () -> SolverOption in
 con MemoedTopDownSolver : () -> SolverOption in
 con SolTreeLazySolver : () -> SolverOption in
+con PaperSolver : () -> SolverOption in
 
 let options =
   { olibs = []
@@ -214,6 +220,7 @@ let argConfig =
         [ ("sat", SATishSolver ())
         , ("lazy-greed", LazyTopDownSolver ())
         , ("top-down", MemoedTopDownSolver ())
+        , ("paper", PaperSolver ())
         , ("mixed-sat-lazy-greed", SolTreeLazySolver ())
         ] in
       let reprSolver = argToString p in
@@ -359,6 +366,7 @@ let ast =
       case LazyTopDownSolver _ then use ComposedLazyTopDownSolver in reprSolve reprOptions ast
       case MemoedTopDownSolver _ then use ComposedMemoedTopDownSolver in reprSolve reprOptions ast
       case SolTreeLazySolver _ then use ComposedMixedSolver in reprSolve reprOptions ast
+      case PaperSolver _ then use ComposedPaperSolver in reprSolve reprOptions ast
       end in
 
     (match options.debugRepr with Some path then

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -139,9 +139,14 @@ lang ComposedMemoedTopDownSolver
   + MemoedTopDownSolver
 end
 
-lang ComposedPaperSolver
+lang ComposedTreeSolverBottomUp
   = MExprRepTypesSolverBase
-  + PaperSolver
+  + TreeSolverBottomUp
+end
+
+lang ComposedTreeSolverGreedy
+  = MExprRepTypesSolverBase
+  + TreeSolverGreedy
 end
 
 mexpr
@@ -153,13 +158,15 @@ con SATishSolver : () -> SolverOption in
 con LazyTopDownSolver : () -> SolverOption in
 con MemoedTopDownSolver : () -> SolverOption in
 con SolTreeLazySolver : () -> SolverOption in
-con PaperSolver : () -> SolverOption in
+con TreeSolverBottomUp : () -> SolverOption in
+con TreeSolverGreedy : () -> SolverOption in
 
 let options =
   { olibs = []
   , clibs = []
 
-  , reprSolver = LazyTopDownSolver ()
+  -- , reprSolver = LazyTopDownSolver ()
+  , reprSolver = TreeSolverGreedy ()
   , useRepr = true
   , useTuning = true
   , debugMExpr = None ()
@@ -220,7 +227,8 @@ let argConfig =
         [ ("sat", SATishSolver ())
         , ("lazy-greed", LazyTopDownSolver ())
         , ("top-down", MemoedTopDownSolver ())
-        , ("paper", PaperSolver ())
+        , ("tree-bottom-up", TreeSolverBottomUp ())
+        , ("tree-greedy", TreeSolverGreedy ())
         , ("mixed-sat-lazy-greed", SolTreeLazySolver ())
         ] in
       let reprSolver = argToString p in
@@ -366,7 +374,8 @@ let ast =
       case LazyTopDownSolver _ then use ComposedLazyTopDownSolver in reprSolve reprOptions ast
       case MemoedTopDownSolver _ then use ComposedMemoedTopDownSolver in reprSolve reprOptions ast
       case SolTreeLazySolver _ then use ComposedMixedSolver in reprSolve reprOptions ast
-      case PaperSolver _ then use ComposedPaperSolver in reprSolve reprOptions ast
+      case TreeSolverBottomUp _ then use ComposedTreeSolverBottomUp in reprSolve reprOptions ast
+      case TreeSolverGreedy _ then use ComposedTreeSolverGreedy in reprSolve reprOptions ast
       end in
 
     (match options.debugRepr with Some path then

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -36,8 +36,10 @@ lang MCoreCompile
   + HtmlAnnotator
   + LogfBuiltin
   + MCoreCompileLang
+  + MetaVarTypeCmp
   + MetaVarTypePrettyPrint
   + MExprCmp
+  + MExprConstType
   + MExprEval
   + MExprLowerNestedPatterns
   + MExprPrettyPrint
@@ -63,17 +65,20 @@ lang MCoreCompile
 end
 
 lang RepAnalysis
-  = MExprRepTypesAnalysis
+  = MetaVarTypeCmp
   + MExprCmp
-  + RepTypesCmp
   + MExprPrettyPrint
-  + RepTypesPrettyPrint
-  + OCamlExtrasTypeCheck
+  + MExprRepTypesAnalysis
+  + OCamlExtrasCmp
   + OCamlExtrasPprint
+  + OCamlExtrasTypeCheck
+  + RepTypesCmp
+  + RepTypesPrettyPrint
 end
 
 lang MExprRepTypesSolverBase
   = AllTypeGeneralize
+  + MetaVarTypeCmp
   + MetaVarTypeGeneralize
   + MetaVarTypePrettyPrint
   + MExprAst

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -149,6 +149,11 @@ lang ComposedTreeSolverGreedy
   + TreeSolverGreedy
 end
 
+lang ComposedTreeSolverGuided
+  = MExprRepTypesSolverBase
+  + TreeSolverGuided
+end
+
 mexpr
 
 use MCoreCompile in
@@ -160,13 +165,14 @@ con MemoedTopDownSolver : () -> SolverOption in
 con SolTreeLazySolver : () -> SolverOption in
 con TreeSolverBottomUp : () -> SolverOption in
 con TreeSolverGreedy : () -> SolverOption in
+con TreeSolverGuided : () -> SolverOption in
 
 let options =
   { olibs = []
   , clibs = []
 
   -- , reprSolver = LazyTopDownSolver ()
-  , reprSolver = TreeSolverGreedy ()
+  , reprSolver = TreeSolverGuided ()
   , useRepr = true
   , useTuning = true
   , debugMExpr = None ()
@@ -229,6 +235,7 @@ let argConfig =
         , ("top-down", MemoedTopDownSolver ())
         , ("tree-bottom-up", TreeSolverBottomUp ())
         , ("tree-greedy", TreeSolverGreedy ())
+        , ("tree-guided", TreeSolverGuided ())
         , ("mixed-sat-lazy-greed", SolTreeLazySolver ())
         ] in
       let reprSolver = argToString p in
@@ -376,6 +383,7 @@ let ast =
       case SolTreeLazySolver _ then use ComposedMixedSolver in reprSolve reprOptions ast
       case TreeSolverBottomUp _ then use ComposedTreeSolverBottomUp in reprSolve reprOptions ast
       case TreeSolverGreedy _ then use ComposedTreeSolverGreedy in reprSolve reprOptions ast
+      case TreeSolverGuided _ then use ComposedTreeSolverGuided in reprSolve reprOptions ast
       end in
 
     (match options.debugRepr with Some path then

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -440,7 +440,7 @@ recursive
     cont options (symbolize ast)
 
   let typeCheckPhase = lam options. lam ast. lam cont.
-    let ast = typeCheckLeaveMeta in
+    let ast = typeCheckLeaveMeta ast in
     (match options.debugTypeCheck with Some path then
        writeFile path (pprintAst ast)
      else ());
@@ -575,7 +575,7 @@ recursive
   let compilePhase = lam options. lam ast. lam cont.
     match options.destinationFile with Some destinationFile in
     if options.doCompile then
-      compile option.olibs options.clibs ast destinationFile;
+      compile options.olibs options.clibs ast destinationFile;
       cont options ast
     else cont options ast
 in
@@ -593,10 +593,10 @@ in
 pipeline options ast
   [ ("symbolize", symbolizePhase)
   , ("typeCheck", typeCheckPhase)
-  , ("desugarExpr", desugarExpr)
-  , ("generateUtestPhase", generateUtestPhase)
+  , ("desugar", desugarPhase)
+  , ("generateUtest", generateUtestPhase)
   , ("reprAnalysis", reprAnalysisPhase)
-  , ("tuningPhase", tuningPhase)
+  , ("tuning", tuningPhase)
   , ("remMetaVar", remMetaVarPhase)
   , ("patLower", patLowerPhase)
   , ("compile", compilePhase)

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -123,6 +123,12 @@ lang ComposedSATIshSolver
   + SATishSolver
 end
 
+lang ComposedMixedSolver
+  = MExprRepTypesSolverBase
+  + SolTreeLazySolver
+  + SATishSolver
+end
+
 lang ComposedLazyTopDownSolver
   = MExprRepTypesSolverBase
   + LazyTopDownSolver
@@ -141,6 +147,7 @@ type SolverOption in
 con SATishSolver : () -> SolverOption in
 con LazyTopDownSolver : () -> SolverOption in
 con MemoedTopDownSolver : () -> SolverOption in
+con SolTreeLazySolver : () -> SolverOption in
 
 let options =
   { olibs = []
@@ -207,6 +214,7 @@ let argConfig =
         [ ("sat", SATishSolver ())
         , ("lazy-greed", LazyTopDownSolver ())
         , ("top-down", MemoedTopDownSolver ())
+        , ("mixed-sat-lazy-greed", SolTreeLazySolver ())
         ] in
       let reprSolver = argToString p in
       match mapLookup reprSolver mapping with Some reprSolver
@@ -350,6 +358,7 @@ let ast =
       case SATishSolver _ then use ComposedSATIshSolver in reprSolve reprOptions ast
       case LazyTopDownSolver _ then use ComposedLazyTopDownSolver in reprSolve reprOptions ast
       case MemoedTopDownSolver _ then use ComposedMemoedTopDownSolver in reprSolve reprOptions ast
+      case SolTreeLazySolver _ then use ComposedMixedSolver in reprSolve reprOptions ast
       end in
 
     (match options.debugRepr with Some path then

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -154,6 +154,20 @@ lang ComposedTreeSolverGuided
   + TreeSolverGuided
 end
 
+lang ComposedTreeSolverZ3
+  = MExprRepTypesSolverBase
+  + TreeSolverZ3
+  sem tyToZ3 boundTyVars state =
+  | TyOpaqueOCaml x -> (state, join ["(opaqueTy \"", x.content, "\""])
+  | TyOString _ -> (state, "ostringTy")
+  | TyOList _ -> (state, "olistTy")
+end
+
+lang ComposedTreeSolverExplore
+  = MExprRepTypesSolverBase
+  + TreeSolverExplore
+end
+
 mexpr
 
 use MCoreCompile in
@@ -166,6 +180,8 @@ con SolTreeLazySolver : () -> SolverOption in
 con TreeSolverBottomUp : () -> SolverOption in
 con TreeSolverGreedy : () -> SolverOption in
 con TreeSolverGuided : () -> SolverOption in
+con TreeSolverZ3 : () -> SolverOption in
+con TreeSolverExplore : () -> SolverOption in
 
 let options =
   { olibs = []
@@ -236,6 +252,8 @@ let argConfig =
         , ("tree-bottom-up", TreeSolverBottomUp ())
         , ("tree-greedy", TreeSolverGreedy ())
         , ("tree-guided", TreeSolverGuided ())
+        , ("tree-z3", TreeSolverZ3 ())
+        , ("tree-explore", TreeSolverExplore ())
         , ("mixed-sat-lazy-greed", SolTreeLazySolver ())
         ] in
       let reprSolver = argToString p in
@@ -384,6 +402,8 @@ let ast =
       case TreeSolverBottomUp _ then use ComposedTreeSolverBottomUp in reprSolve reprOptions ast
       case TreeSolverGreedy _ then use ComposedTreeSolverGreedy in reprSolve reprOptions ast
       case TreeSolverGuided _ then use ComposedTreeSolverGuided in reprSolve reprOptions ast
+      case TreeSolverZ3 _ then use ComposedTreeSolverZ3 in reprSolve reprOptions ast
+      case TreeSolverExplore _ then use ComposedTreeSolverExplore in reprSolve reprOptions ast
       end in
 
     (match options.debugRepr with Some path then

--- a/src/compiler/pprint.mc
+++ b/src/compiler/pprint.mc
@@ -9,8 +9,6 @@ lang OCamlStringPprint = PrettyPrint + OCamlStringAst + ConstPrettyPrint
   sem getTypeStringCode indent env =
   | TyOString _ -> (env, "string")
 
-  sem patIsAtomic =
-  | PatOString _ -> true
   sem getPatStringCode indent env =
   | PatOString x -> (env, join ["\"", escapeString x.val, "\""])
 end
@@ -27,8 +25,11 @@ lang OCamlOpaquePprint = PrettyPrint + OpaqueOCamlAst
   | TyOpaqueOCaml x -> (env, x.content)
 
   -- Pat
-  sem patIsAtomic =
-  | PatOpaqueOCamlCon x -> optionIsNone x.arg
+  sem patPrecedence =
+  | PatOpaqueOCamlCon x ->
+    if optionIsNone x.arg
+    then 100000
+    else 2
   sem getPatStringCode indent env =
   | PatOpaqueOCamlCon x ->
     match optionMapAccum (getPatStringCode indent) env x.arg with (env, arg) in
@@ -47,9 +48,8 @@ lang OCamlListPprint = PrettyPrint + OCamlListAst + ConstPrettyPrint
     match getTypeStringCode indent env x.elem with (env, elem) in
     (env, join ["OList ", elem])
 
-  sem patIsAtomic =
-  | PatOCons _ -> false
-  | PatONil _ -> true
+  sem patPrecedence =
+  | PatOCons _ -> 0
   sem getPatStringCode indent env =
   | PatOCons x ->
     match getPatStringCode indent env x.head with (env, head) in

--- a/src/compiler/syntax.syn
+++ b/src/compiler/syntax.syn
@@ -101,6 +101,9 @@ token {fragment = UnitTokenParser,}
 token {fragment = OCamlMultilineCommentParser,}
 token {fragment = WhitespaceParser,}
 
+-- Errors
+token {fragment = ErrorTokenParser,}
+
 -- Tops
 prod LetOTop : OTop =
   "let" rec:"rec"? bindings:OBinding ("and" bindings:OBinding)* ";;"


### PR DESCRIPTION
This PR makes some updates because of changes in Miking (primarily #807) as well as changes in the reptypes stuff (#836). Other changes:

- Many new repr solvers.
- Some new flags, `--no-compile` and `--debug-phases` probably most generally useful.
- The main compiler pipeline is restructured to be a sequence of continuation-passing style functions, for two reasons:
  - Better at-a-glance overview of order and such
  - The ability to run "the rest of the pipeline" multiple times, primarily used when the user requests all repr-solutions for a program, which must then be able to produce multiple executables.