### PR TITLE
Fix compilation after miking updates

### DIFF
--- a/src/compiler/cfa.mc
+++ b/src/compiler/cfa.mc
@@ -9,7 +9,7 @@ end
 
 lang OCamlOpaqueCFA = CFA + OpaqueOCamlAst
   sem generateConstraints graph =
-  | TmLet { ident = ident, body = TmOpaqueOCaml _, info = info } -> graph
+  | TmDecl {decl = DeclLet {ident = ident, body = TmOpaqueOCaml _}} -> graph
 
 end
 

--- a/src/compiler/main.mc
+++ b/src/compiler/main.mc
@@ -397,8 +397,7 @@ let argConfig =
 let compile : [String] -> [String] -> Expr -> String -> () =
   lam olibs. lam clibs. lam ast. lam destinationFile.
     compileMCore ast
-      { debugTypeAnnot = lam. ()
-      , debugGenerate = lam. ()
+      { debugGenerate = lam. ()
       , exitBefore = lam. ()
       , postprocessOcamlTops = lam x. x
       , compileOcaml = lam ol. lam cl. lam srcStr.
@@ -580,10 +579,10 @@ recursive
     else cont options ast
 in
 let pipeline = lam options. lam ast. lam phases.
-  let log = mkPhaseLogState options.debugPhases in
+  let log = mkPhaseLogState (setEmpty cmpString) options.debugPhases in
   let step = lam phase. lam next. lam options. lam ast.
     let next = lam options. lam ast.
-      endPhaseStats log phase.0 ast;
+      endPhaseStats log phase.0 (Left ast);
       next options ast in
     phase.1 options ast next in
   let composed = foldr step (lam. lam. ()) phases in

--- a/src/compiler/prelude.mc
+++ b/src/compiler/prelude.mc
@@ -13,5 +13,5 @@ lang OCamlPrelude = ReprTypeAst + OCamlListAst + OCamlStringAst
       , type_ "bool" [] tybool_
       , type_ "unit" [] tyunit_
       ] in
-    bindall_ (snoc bindings tm)
+    bindall_ bindings tm
 end


### PR DESCRIPTION
This updates the `mi-ml` compiler such that it compiles and appears to work in basic testing of the reptypes stuff. This includes the changes introduced in https://github.com/miking-lang/miking/pull/951.